### PR TITLE
Remove uneeded require statements.

### DIFF
--- a/src/IJuliaWidgets.jl
+++ b/src/IJuliaWidgets.jl
@@ -1,5 +1,3 @@
-require("React")
-require("Interact")
 
 module IJuliaWidgets
 


### PR DESCRIPTION
The `require` statements aren't needed anymore in Julia, and removing them seems to fix the infinite loop issue.
